### PR TITLE
Added code to update user:pi status

### DIFF
--- a/scripts/hex_firsttime.sh
+++ b/scripts/hex_firsttime.sh
@@ -23,5 +23,6 @@ mv ./sshd_config /etc/ssh/sshd_config   # Moves the sshd_config file from earlie
 
 
 
-useradd -m -p control                    # Adds a user called 'control'
-echo control:defaultpassword | chpasswd  # Changes the password of 'control' to 'defaultpassword' by piping it into chpasswd
+useradd -m -p control                   	# Adds a user called 'control'
+echo control:defaultpassword | chpasswd 	# Changes the password of 'control' to 'defaultpassword' by piping it into chpasswd
+# passwd -l pi	 							# Locks the Pi user for security reasons


### PR DESCRIPTION
Added code (and commented out for the time being) the default user of
'Pi' to keep it from being used in any way. This should help to improve
the security of the device overall.